### PR TITLE
hotfix: PR workflow重複実行の修正

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches: [main, develop]
 
 # 同一PRで複数実行時は前の実行をキャンセル
 concurrency:


### PR DESCRIPTION
## Summary
- pull_requestとpull_request_targetの両方が設定されていたため同じジョブが2倍(10個)実行されていた問題を修正
- ジョブ数を期待される5個に削減

## 問題
PRを作成すると以下のような状況で同じジョブが2回実行されていました：
- `PR Tests / Backend Tests (pull_request)`
- `PR Tests / Backend Tests (pull_request_target)`

合計10個のジョブが実行され、期待される5個の2倍となっていました。

## pull_request vs pull_request_target の違い
- **pull_request**: PRの作成者の権限で実行、セキュリティリスクが低い
- **pull_request_target**: リポジトリの権限で実行、セキュリティリスクが高い

## 修正内容
`.github/workflows/pr-tests.yml`から`pull_request_target`を削除：
```yaml
on:
  pull_request:
    branches: [main, develop]
    types: [opened, synchronize, reopened]
  # pull_request_target を削除
```

## 理由
- 内部開発のためセキュリティリスクの低い`pull_request`で十分
- フォークからの貢献を受けない限り`pull_request_target`は不要
- 重複実行によるCI時間の無駄を排除

## Test plan
- [ ] PRでジョブが5個のみ実行されることを確認
- [ ] 各ジョブが1回のみ実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)