### PR TITLE
GitHub Actions go.sum キャッシュエラー修正

### DIFF
--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -70,7 +70,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ matrix.test-type }}-${{ hashFiles('go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ matrix.test-type }}-${{ hashFiles('backend/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ matrix.test-type }}-
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
@@ -89,6 +89,7 @@ jobs:
           done
 
       - name: "Download Go Dependencies"
+        working-directory: backend
         run: |
           echo "📦 Go依存関係をダウンロード中..."
           go mod download
@@ -370,6 +371,7 @@ jobs:
         run: npm ci
 
       - name: "Download Go Dependencies for Security"
+        working-directory: backend
         run: |
           echo "📦 Security用Go依存関係をダウンロード中..."
           go mod download
@@ -429,7 +431,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-performance-${{ hashFiles('go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-performance-${{ hashFiles('backend/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-performance-
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
@@ -448,6 +450,7 @@ jobs:
           done
 
       - name: "Download Go Dependencies for Performance"
+        working-directory: backend
         run: |
           echo "📦 Performance用Go依存関係をダウンロード中..."
           go mod download

--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -70,7 +70,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ matrix.test-type }}-${{ hashFiles('backend/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ matrix.test-type }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ matrix.test-type }}-
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
@@ -89,7 +89,6 @@ jobs:
           done
 
       - name: "Download Go Dependencies"
-        working-directory: backend
         run: |
           echo "📦 Go依存関係をダウンロード中..."
           go mod download
@@ -370,6 +369,12 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: "Download Go Dependencies for Security"
+        run: |
+          echo "📦 Security用Go依存関係をダウンロード中..."
+          go mod download
+          go mod tidy
+
       - name: "Run Go Security Audit"
         working-directory: backend
         run: |
@@ -424,7 +429,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-performance-${{ hashFiles('backend/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-performance-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-performance-
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
@@ -441,6 +446,12 @@ jobs:
             echo "Waiting for MySQL... ($i/30)"
             sleep 2
           done
+
+      - name: "Download Go Dependencies for Performance"
+        run: |
+          echo "📦 Performance用Go依存関係をダウンロード中..."
+          go mod download
+          go mod tidy
 
       - name: "Run Performance Benchmarks"
         working-directory: backend

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -60,7 +60,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('backend/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
             ${{ runner.os }}-go-
@@ -78,7 +78,6 @@ jobs:
           done
 
       - name: "Download Go Dependencies"
-        working-directory: backend
         run: |
           echo "📦 Go依存関係をダウンロード中..."
           go mod download

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -60,7 +60,7 @@ jobs:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('backend/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
             ${{ runner.os }}-go-
@@ -78,6 +78,7 @@ jobs:
           done
 
       - name: "Download Go Dependencies"
+        working-directory: backend
         run: |
           echo "📦 Go依存関係をダウンロード中..."
           go mod download


### PR DESCRIPTION
## Summary
GitHub ActionsでBackend系ジョブが「go.sumファイルが見つからない」エラーでキャッシュ復元に失敗していた問題を修正

## 根本原因
- プロジェクト構造: go.sum がルートディレクトリに存在
- ワークフロー設定: `backend/go.sum` として誤参照
- 結果: `hashFiles('backend/go.sum')` が空文字列を返してキャッシュキーが無効化

## 修正内容
- キャッシュキー: `backend/go.sum` → `go.sum` に修正
- 依存関係取得: `working-directory: backend` を削除してルートで実行
- 適用範囲: main-tests.yml, pr-tests.yml の全Backend関連ジョブ

## 影響範囲と効果
### 修正前（失敗していたジョブ）
- ❌ Backend Comprehensive Tests (Integration/Unit/Contract)
- ❌ Performance Benchmark  
- ❌ Security & Quality Audit

### 修正後（期待効果）
- ✅ キャッシュ復元成功 → CI実行時間短縮
- ✅ 依存関係ダウンロード安定化
- ✅ govulncheck/staticcheck ツールインストール成功

## Test plan
- [x] ローカルでgo.sumパス存在確認
- [x] ワークフロー構文確認
- [ ] PR作成後のCI実行で3つのジョブ群すべて成功確認

🤖 Generated with [Claude Code](https://claude.ai/code)