### PR TITLE
フロントエンドテスト: ローディング状態待機ロジック修正

### DIFF
--- a/frontend/src/test/components/BillsListPage.test.tsx
+++ b/frontend/src/test/components/BillsListPage.test.tsx
@@ -255,13 +255,11 @@ describe("BillsListPage - 重複チェック機能", () => {
   const openCreateModal = async () => {
     render(<BillsListPage />);
 
-    // データの読み込み完了を待つ
-    await waitFor(() => {
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-    });
-
-    // 新規作成ボタンをクリック（より堅牢なセレクター使用）
-    const createButton = screen.getByRole("button", { name: /新規作成/ });
+    // データの読み込み完了を待つ（新規作成ボタンが表示されるまで）
+    const createButton = await waitFor(
+      () => screen.getByRole("button", { name: /新規作成/ }),
+      { timeout: 10000 },
+    );
     await user.click(createButton);
 
     // モーダルが開かれることを確認

--- a/frontend/src/test/integration/api-error-handling.test.tsx
+++ b/frontend/src/test/integration/api-error-handling.test.tsx
@@ -53,13 +53,11 @@ describe("APIエラーハンドリング統合テスト", () => {
   const openCreateModalAndFillForm = async () => {
     render(<BillsListPage />);
 
-    // データの読み込み完了を待つ
-    await waitFor(() => {
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-    });
-
-    // 新規作成ボタンをクリック（より堅牢なセレクター使用）
-    const createButton = screen.getByRole("button", { name: /新規作成/ });
+    // データの読み込み完了を待つ（新規作成ボタンが表示されるまで）
+    const createButton = await waitFor(
+      () => screen.getByRole("button", { name: /新規作成/ }),
+      { timeout: 10000 },
+    );
     await user.click(createButton);
 
     const comboboxes = screen.getAllByRole("combobox");


### PR DESCRIPTION
## 問題
mainCI Frontend Comprehensive Tests で新規作成ボタンが見つからない
- BillsListPageが永続的にローディングスピナー状態で止まる
- エラー: `Unable to find an accessible element with the role "button" and name /新規作成/`

## 根本原因
`waitFor(() => screen.queryByText("Loading..."))` による待機が不適切
- **実際のローディング**: スピナー要素（`animate-spin`クラス）
- **テストの期待**: "Loading..."テキスト
- **結果**: CI環境でローディング完了を検知できず永続的に待機

## 修正内容
### より確実な待機ロジックに変更
```tsx
// 修正前: Loading...テキスト待機（不安定）
await waitFor(() => {
  expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
});
const createButton = screen.getByRole("button", { name: /新規作成/ });

// 修正後: 目的要素の直接待機（確実）
const createButton = await waitFor(
  () => screen.getByRole("button", { name: /新規作成/ }),
  { timeout: 10000 },
);
```

### 修正ファイル
- `frontend/src/test/components/BillsListPage.test.tsx`
- `frontend/src/test/integration/api-error-handling.test.tsx`

## テスト結果
✅ **BillsListPage.test.tsx**: 18 tests 全てパス (910ms)  
✅ **api-error-handling.test.tsx**: 11 tests 全てパス (1127ms)

## 改善効果
- CI環境でのテスト安定性向上
- タイムアウト延長 (10秒) でCI実行時間を考慮
- 目的要素への直接待機で確実性向上

## Test plan
- [x] ローカルテスト実行で両ファイルとも成功確認
- [ ] PR CI でフロントエンドテスト成功確認
- [ ] mainCI Frontend Comprehensive Tests 問題解決確認

🤖 Generated with [Claude Code](https://claude.ai/code)